### PR TITLE
Test with latest and make semver explicit

### DIFF
--- a/dynatrace/build.gradle
+++ b/dynatrace/build.gradle
@@ -20,7 +20,7 @@ plugins {
 }
 
 group = "com.dynatrace.opentelemetry.metric"
-version = "1.0.0"
+version = "1.1.0"
 
 repositories {
     mavenCentral()

--- a/dynatrace/build.gradle
+++ b/dynatrace/build.gradle
@@ -26,13 +26,11 @@ repositories {
     mavenCentral()
 }
 
+def minOtelVersion = "1.14.0"
+def testOtelVersion = "1.21.0"
+
 dependencies {
-    compileOnly platform("io.opentelemetry:opentelemetry-bom") {
-        version {
-            strictly '[1.14.0, 2.0['
-            prefer '1.20.1'
-        }
-    }
+    compileOnly platform("io.opentelemetry:opentelemetry-bom:${minOtelVersion}")
     compileOnly('io.opentelemetry:opentelemetry-sdk')
     compileOnly('io.opentelemetry:opentelemetry-sdk-metrics')
 
@@ -48,14 +46,8 @@ dependencies {
     testImplementation("org.mockito:mockito-core:3.12.4")
     testImplementation('io.opentelemetry:opentelemetry-sdk-testing')
 
-    testImplementation platform("io.opentelemetry:opentelemetry-bom") {
-        version {
-            strictly '[1.14.0, 2.0['
-            prefer '1.20.1'
-        }
-    }
-    testImplementation('io.opentelemetry:opentelemetry-sdk')
-    testImplementation('io.opentelemetry:opentelemetry-sdk-metrics')
+    testImplementation platform("io.opentelemetry:opentelemetry-bom:${testOtelVersion}")
+    testImplementation ("io.opentelemetry:opentelemetry-sdk-testing:${testOtelVersion}")
 }
 
 test {

--- a/dynatrace/build.gradle
+++ b/dynatrace/build.gradle
@@ -27,14 +27,14 @@ repositories {
 }
 
 dependencies {
-    implementation platform("io.opentelemetry:opentelemetry-bom") {
+    compileOnly platform("io.opentelemetry:opentelemetry-bom") {
         version {
             strictly '[1.14.0, 2.0['
             prefer '1.20.1'
         }
     }
-    implementation('io.opentelemetry:opentelemetry-sdk')
-    implementation('io.opentelemetry:opentelemetry-sdk-metrics')
+    compileOnly('io.opentelemetry:opentelemetry-sdk')
+    compileOnly('io.opentelemetry:opentelemetry-sdk-metrics')
 
     implementation("com.google.guava:guava:30.0-jre")
 
@@ -47,6 +47,15 @@ dependencies {
 
     testImplementation("org.mockito:mockito-core:3.12.4")
     testImplementation('io.opentelemetry:opentelemetry-sdk-testing')
+
+    testImplementation platform("io.opentelemetry:opentelemetry-bom") {
+        version {
+            strictly '[1.14.0, 2.0['
+            prefer '1.20.1'
+        }
+    }
+    testImplementation('io.opentelemetry:opentelemetry-sdk')
+    testImplementation('io.opentelemetry:opentelemetry-sdk-metrics')
 }
 
 test {

--- a/dynatrace/build.gradle
+++ b/dynatrace/build.gradle
@@ -26,10 +26,13 @@ repositories {
     mavenCentral()
 }
 
-def otelVersion = '1.14.0'
-
 dependencies {
-    implementation platform("io.opentelemetry:opentelemetry-bom:${otelVersion}")
+    implementation platform("io.opentelemetry:opentelemetry-bom") {
+        version {
+            strictly '[1.14.0, 2.0['
+            prefer '1.20.1'
+        }
+    }
     implementation('io.opentelemetry:opentelemetry-sdk')
     implementation('io.opentelemetry:opentelemetry-sdk-metrics')
 

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -22,7 +22,7 @@ plugins {
 mainClassName = "com.dynatrace.opentelemetry.metric.example.DynatraceExporterExample"
 
 group = "com.dynatrace.opentelemetry.metric.example"
-version = "0.5.0"
+version = "0.6.0"
 
 repositories {
     mavenCentral()

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -28,10 +28,10 @@ repositories {
     mavenCentral()
 }
 
-def otelVersion = '1.14.0'
+def otelVersion = '1.20.1'
 
 dependencies {
-    implementation platform("io.opentelemetry:opentelemetry-bom:${otelVersion}")
+    implementation platform("io.opentelemetry:opentelemetry-bom:${otelVersion}!!")
     implementation("io.opentelemetry:opentelemetry-api")
     implementation("io.opentelemetry:opentelemetry-sdk")
 

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -28,7 +28,7 @@ repositories {
     mavenCentral()
 }
 
-def otelVersion = '1.20.1'
+def otelVersion = '1.21.0'
 
 dependencies {
     implementation platform("io.opentelemetry:opentelemetry-bom:${otelVersion}!!")


### PR DESCRIPTION
Updates the version range of OTel to be semver compliant requiring a minimum of 1.14 (metrics stability) and excluding versions 2.0 or above (potentially breaking).

Updates the example project to use 1.20.1 (latest)