### PR TITLE
Verify exporter works with SDK version 1.24.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ dependencies {
 Then run:
 
 ```shell
-gradle assemble
+./gradlew assemble
 ```
 
 Gradle pulls the library in the specified version directly from GitHub and includes it.
@@ -43,8 +43,6 @@ To use the library, we first need to create a `DynatraceMetricExporter`.
 The `.getDefault()` method returns an instance which attempts to export to the [local OneAgent endpoint](https://www.dynatrace.com/support/help/how-to-use-dynatrace/metrics/metric-ingestion/ingestion-methods/local-api/).
 
 ```java
-import com.dynatrace.opentelemetry.metric.DynatraceMetricExporter;
-
 DynatraceMetricExporter exporter = DynatraceMetricExporter.getDefault();
 ```
 
@@ -53,8 +51,6 @@ It is recommended to limit the token scope to only this permission.
 More information on setting up API access using tokens can be found [in the documentation](https://www.dynatrace.com/support/help/dynatrace-api/basics/dynatrace-api-authentication/) and in the [Dynatrace API Token](#dynatrace-api-token) section below.
 
 ```java
-import com.dynatrace.opentelemetry.metric.DynatraceMetricExporter;
-
 DynatraceMetricExporter exporter =
     DynatraceMetricExporter.builder()
         .setUrl("https://{your-environment-id}.live.dynatrace.com/api/v2/metrics/ingest")
@@ -65,17 +61,13 @@ DynatraceMetricExporter exporter =
 After acquiring a `DynatraceMetricExporter` object, it has to be registered with the OpenTelemetry SDK using a `MetricReader`:
 
 ```java
-import java.time.Duration;
-import io.opentelemetry.sdk.OpenTelemetrySdk;
-import io.opentelemetry.sdk.metrics.SdkMeterProvider;
-import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
-
 // Create the MeterProvider and register it globally. 
 // The MeterProvider is configured with the PeriodicMetricReader
 // which takes our exporter and the export interval.
 SdkMeterProvider meterProvider =
     SdkMeterProvider.builder()
         .registerMetricReader(
+            // This short export interval is just for demonstration purposes and should not be used in real-world scenarios.
             PeriodicMetricReader.builder(exporter).setInterval(Duration.ofSeconds(1)).build())
         .build();
 
@@ -84,19 +76,12 @@ OpenTelemetrySdk.builder().setMeterProvider(meterProvider).buildAndRegisterGloba
 ```
 
 The interval in which metrics are exported can be set on the `PeriodicMetricReader` (see above).
-In the example case above, metrics are exported every second. This short export interval is just for demonstrating
+In the example case above, metrics are exported every second. This short export interval is just for demonstration
 purposes and should not be used in real-world scenarios.
 
 Once metrics are reported using the Metrics API, data will be exported to Dynatrace in the set interval:
 
 ```java
-import static io.opentelemetry.api.common.AttributeKey.stringKey;
-
-import io.opentelemetry.api.GlobalOpenTelemetry;
-import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.metrics.LongCounter;
-import io.opentelemetry.api.metrics.Meter;
-
 Meter meter =
     GlobalOpenTelemetry
         .getMeterProvider()
@@ -135,10 +120,6 @@ Create `Attributes` using the OpenTelemetry API.
 You can either use the factory methods `of(...)` or the `AttributesBuilder`, e.g.:
 
 ```java
-import static io.opentelemetry.api.common.AttributeKey.stringKey;
-
-import io.opentelemetry.api.common.Attributes;
-
 // Using factory 'of' methods
 Attributes attributes = Attributes.of(stringKey("attr1"), "value1", stringKey("attr2"), "value2");
 

--- a/dynatrace/build.gradle
+++ b/dynatrace/build.gradle
@@ -27,7 +27,7 @@ repositories {
 }
 
 def minOtelVersion = "1.14.0"
-def testOtelVersion = "1.23.1"
+def testOtelVersion = "1.24.0"
 
 dependencies {
     compileOnly platform("io.opentelemetry:opentelemetry-bom:${minOtelVersion}")

--- a/dynatrace/src/test/java/com/dynatrace/opentelemetry/metric/SerializerTest.java
+++ b/dynatrace/src/test/java/com/dynatrace/opentelemetry/metric/SerializerTest.java
@@ -324,8 +324,10 @@ class SerializerTest {
                         NANOS_TS_2,
                         EMPTY_ATTRIBUTES,
                         125.5,
-                        null,
-                        null,
+                        false,
+                        0,
+                        false,
+                        0,
                         Arrays.asList(0.0, 12.5, 50.7),
                         Arrays.asList(0L, 5L, 3L, 0L)),
                     ImmutableHistogramPointData.create(
@@ -333,7 +335,9 @@ class SerializerTest {
                         NANOS_TS_3,
                         EMPTY_ATTRIBUTES,
                         100.4,
+                        true,
                         1.2,
+                        true,
                         32.6,
                         Arrays.asList(2.3, 11.4, 23.6),
                         Arrays.asList(1L, 7L, 4L, 1L)))));
@@ -435,8 +439,10 @@ class SerializerTest {
                         NANOS_TS_2,
                         EMPTY_ATTRIBUTES,
                         Double.NaN,
-                        null,
-                        null,
+                        false,
+                        0,
+                        false,
+                        0,
                         Arrays.asList(0.0, 5.0, 10.0),
                         Arrays.asList(0L, 1L, 2L, 3L)),
                     // +Inf sum
@@ -445,8 +451,10 @@ class SerializerTest {
                         NANOS_TS_2,
                         EMPTY_ATTRIBUTES,
                         Double.POSITIVE_INFINITY,
-                        null,
-                        null,
+                        false,
+                        0,
+                        false,
+                        0,
                         Arrays.asList(0.0, 5.0, 10.0),
                         Arrays.asList(0L, 1L, 2L, 3L)),
                     // -Inf sum
@@ -455,8 +463,10 @@ class SerializerTest {
                         NANOS_TS_2,
                         EMPTY_ATTRIBUTES,
                         Double.NEGATIVE_INFINITY,
-                        null,
-                        null,
+                        false,
+                        0,
+                        false,
+                        0,
                         Arrays.asList(0.0, 5.0, 10.0),
                         Arrays.asList(0L, 1L, 2L, 3L)))));
 
@@ -471,8 +481,10 @@ class SerializerTest {
                 NANOS_TS_2,
                 EMPTY_ATTRIBUTES,
                 10.234,
-                null,
-                null,
+                false,
+                0,
+                false,
+                0,
                 Arrays.asList(Double.NaN, 1.2d, 3.4d, 5.6d),
                 Arrays.asList(0L, 2L, 1L, 3L, 0L)));
     assertThrows(
@@ -483,8 +495,10 @@ class SerializerTest {
                 NANOS_TS_2,
                 EMPTY_ATTRIBUTES,
                 10.234,
-                null,
-                null,
+                false,
+                0,
+                false,
+                0,
                 Arrays.asList(0.1d, 1.2d, 3.4d, Double.POSITIVE_INFINITY),
                 Arrays.asList(0L, 2L, 1L, 3L, 0L)));
     assertThrows(
@@ -495,8 +509,10 @@ class SerializerTest {
                 NANOS_TS_2,
                 EMPTY_ATTRIBUTES,
                 10.234,
-                null,
-                null,
+                false,
+                0,
+                false,
+                0,
                 Arrays.asList(Double.POSITIVE_INFINITY, 1.2d, 3.4d, 5.6d),
                 Arrays.asList(0L, 2L, 1L, 3L, 0L)));
     assertThrows(
@@ -507,8 +523,10 @@ class SerializerTest {
                 NANOS_TS_2,
                 EMPTY_ATTRIBUTES,
                 10.234,
-                null,
-                null,
+                false,
+                0,
+                false,
+                0,
                 Arrays.asList(0.1d, 1.2d, 3.4d, Double.NEGATIVE_INFINITY),
                 Arrays.asList(0L, 2L, 1L, 3L, 0L)));
     assertThrows(
@@ -519,8 +537,10 @@ class SerializerTest {
                 NANOS_TS_2,
                 EMPTY_ATTRIBUTES,
                 10.234,
-                null,
-                null,
+                false,
+                0,
+                false,
+                0,
                 Arrays.asList(Double.NEGATIVE_INFINITY, 1.2d, 3.4d, 5.6d),
                 Arrays.asList(0L, 2L, 1L, 3L, 0L)));
     // Number of bounds does not match number of counts
@@ -532,8 +552,10 @@ class SerializerTest {
                 NANOS_TS_2,
                 EMPTY_ATTRIBUTES,
                 10.234,
-                null,
-                null,
+                false,
+                0,
+                false,
+                0,
                 Arrays.asList(1.2, 3.4),
                 Arrays.asList(0L, 2L, 1L, 3L, 0L)));
   }
@@ -561,7 +583,7 @@ class SerializerTest {
     double minFromBoundaries =
         Serializer.getMinFromBoundaries(
             ImmutableHistogramPointData.create(
-                NANOS_TS_1, NANOS_TS_2, EMPTY_ATTRIBUTES, sum, null, null, bounds, counts));
+                NANOS_TS_1, NANOS_TS_2, EMPTY_ATTRIBUTES, sum, false, 0, false, 0, bounds, counts));
 
     long sumOfCounts = counts.stream().mapToLong(Long::longValue).sum();
     if (sumOfCounts == 0) {
@@ -599,7 +621,7 @@ class SerializerTest {
     double maxFromBoundaries =
         Serializer.getMaxFromBoundaries(
             ImmutableHistogramPointData.create(
-                NANOS_TS_1, NANOS_TS_2, EMPTY_ATTRIBUTES, sum, null, null, bounds, counts));
+                NANOS_TS_1, NANOS_TS_2, EMPTY_ATTRIBUTES, sum, false, 0, false, 0, bounds, counts));
 
     long sumOfCounts = counts.stream().mapToLong(Long::longValue).sum();
     if (sumOfCounts == 0) {

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -28,7 +28,7 @@ repositories {
     mavenCentral()
 }
 
-def otelVersion = '1.23.1'
+def otelVersion = '1.24.0'
 
 dependencies {
     implementation platform("io.opentelemetry:opentelemetry-bom:${otelVersion}!!")


### PR DESCRIPTION
Verified that our metrics exporter works in applications using the OpenTelemetry Java SDK version 1.24.0

- Updated SDK version in tests and in the sample app
- Verified the sample in README.md still works
- Adapted the README.md a bit so a complete new app is working by following all the steps