### PR TITLE
chore: bump example and test version to 1.31.0

### DIFF
--- a/dynatrace/build.gradle
+++ b/dynatrace/build.gradle
@@ -27,7 +27,7 @@ repositories {
 }
 
 def minOtelVersion = "1.14.0"
-def testOtelVersion = "1.30.1"
+def testOtelVersion = "1.31.0"
 
 dependencies {
     compileOnly platform("io.opentelemetry:opentelemetry-bom:${minOtelVersion}")

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -28,7 +28,7 @@ repositories {
     mavenCentral()
 }
 
-def otelVersion = '1.30.1'
+def otelVersion = '1.31.0'
 
 dependencies {
     implementation platform("io.opentelemetry:opentelemetry-bom:${otelVersion}!!")


### PR DESCRIPTION
this PR bumps the test and example verison to 1.31.0.
Tested locally, everything is working as expected.