### PR TITLE
chore: bump example and test version to 1.33.0

### DIFF
--- a/dynatrace/build.gradle
+++ b/dynatrace/build.gradle
@@ -27,7 +27,7 @@ repositories {
 }
 
 def minOtelVersion = "1.14.0"
-def testOtelVersion = "1.32.0"
+def testOtelVersion = "1.33.0"
 
 dependencies {
     compileOnly platform("io.opentelemetry:opentelemetry-bom:${minOtelVersion}")

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -28,7 +28,7 @@ repositories {
     mavenCentral()
 }
 
-def otelVersion = '1.32.0'
+def otelVersion = '1.33.0'
 
 dependencies {
     implementation platform("io.opentelemetry:opentelemetry-bom:${otelVersion}!!")


### PR DESCRIPTION
This PR bumps the OTel test and example versions to 1.33.0. 

